### PR TITLE
Update _bertopic.py to fix question/ github issue #1696

### DIFF
--- a/bertopic/_bertopic.py
+++ b/bertopic/_bertopic.py
@@ -456,7 +456,10 @@ class BERTopic:
         """ After having fit a model, use transform to predict new instances
 
         Arguments:
-            documents: A single document or a list of documents to predict on
+            documents: A single document or a list of documents to predict on.                    
+                       Note that the behavior of the method might differ depending 
+                       on whether a single document or a list of documents is passed
+                       (especially when using the HDBSCAN algorithm)
             embeddings: Pre-trained document embeddings. These can be used
                         instead of the sentence-transformer model.
             images: A list of paths to the images to predict on or the images themselves


### PR DESCRIPTION
As discussed in [ #1696 ](https://github.com/MaartenGr/BERTopic/issues/1696), I provide an updated doc string to reflect that `topic_model.transform(docs)[0][i] `is sometimes different from `topic_model.transform(docs[i])[0][0] `